### PR TITLE
Add http://0.0.0.0:8080 to cors whitelist

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
   "corsWhitelist": [
-    "http://localhost:8080"
+    "http://localhost:8080",
+    "http://0.0.0.0:8080"
   ],
   "dbConnection": {
     "host": "127.0.0.1",


### PR DESCRIPTION
resistr-ui [uses `--host 0.0.0.0`](https://github.com/jacobmoe/resistr-ui/blob/master/makefile#L16),
so seems like it might be good to explicitly whitelist it.